### PR TITLE
fixed ImportError: cannot import name 'AnsibleLintRule' from 'ansiblelint'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: bionic
-sudo: required
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+dist: bionic
+sudo: required
+
 language: python
 python:
-  - "2.7"
-  - "3.5"
-#  - "3.7" waiting for support in travis https://github.com/travis-ci/travis-ci/issues/9552
+  - "3.8"
+
 install:
   - pip install ansible-lint
 script:

--- a/rules/MetaShouldHaveDependencies.py
+++ b/rules/MetaShouldHaveDependencies.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MetaShouldHaveDependencies(AnsibleLintRule):

--- a/rules/MetaShouldHaveIssueTracker.py
+++ b/rules/MetaShouldHaveIssueTracker.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MetaShouldHaveIssueTracker(AnsibleLintRule):

--- a/rules/MetaShouldHaveRoleName.py
+++ b/rules/MetaShouldHaveRoleName.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class MetaShouldHaveRoleName(AnsibleLintRule):

--- a/rules/ModulePipWithoutWithItems.py
+++ b/rules/ModulePipWithoutWithItems.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import os
 
 class ModulePipWithoutWithItems(AnsibleLintRule):

--- a/rules/ModuleTemplateExt.py
+++ b/rules/ModuleTemplateExt.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import os
 
 class ModuleTemplateExt(AnsibleLintRule):

--- a/rules/ModuleYumWithoutWithItems.py
+++ b/rules/ModuleYumWithoutWithItems.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import os
 
 class ModuleYumWithoutWithItems(AnsibleLintRule):

--- a/rules/PackageHasRetryRule.py
+++ b/rules/PackageHasRetryRule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Will Thames and contributors
 # Copyright (c) 2018, Ansible Project
 
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 
 class PackageHasRetryRule(AnsibleLintRule):

--- a/rules/TaskIncludeShouldHaveTags.py
+++ b/rules/TaskIncludeShouldHaveTags.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 # FIXME: how to get include task?
 class TaskIncludeShouldHaveTags(AnsibleLintRule):

--- a/rules/TaskManyArgs.py
+++ b/rules/TaskManyArgs.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 class TaskManyArgs(AnsibleLintRule):
     id = 'E303'

--- a/rules/TaskVariableHasLowerCase.py
+++ b/rules/TaskVariableHasLowerCase.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 import re
 

--- a/rules/UseDictItems.py
+++ b/rules/UseDictItems.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 import re
 
 class UseDictItems(AnsibleLintRule):

--- a/rules/UseNonCapitalInTrueFalse.py
+++ b/rules/UseNonCapitalInTrueFalse.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 import re
 

--- a/rules/UseTrueFalseInsteadYesNo.py
+++ b/rules/UseTrueFalseInsteadYesNo.py
@@ -1,4 +1,4 @@
-from ansiblelint import AnsibleLintRule
+from ansiblelint.rules import AnsibleLintRule
 
 import re
 


### PR DESCRIPTION
fixed ImportError: cannot import name 'AnsibleLintRule' from 'ansiblelint' (/opt/toolset/lib/python3.8/site-packages/ansiblelint/__init__.py)

How to reproduce the issue:
Python version 3.8

1. $ git clone https://github.com/lean-delivery/ansible-lint-rules.git ~/ansible-lint-rules
2. $ git clone https://github.com/dzianis-fisiuk/ansible-role-myrole1.git ~/ansible-role-myrole1
4. $ cd ~/ansible-role-myrole1
5. check .ansible-lint file content:
---
exclude_paths:
 - ./.travis.yml
 - ./molecule/
rulesdir:
  - ~/ansible-lint-rules/rules/
use_default_rules: true
verbosity: 1
4. Run ansible-lint command:
$ ansible-lint . -c .ansible-lint

Error output:
INFO     Running ansible-galaxy role install --roles-path /root/.cache/ansible-lint/af766b/roles -vr requirements.yml
WARNING  Computed fully qualified role name of myrole1 does not follow current galaxy requirements.
Please edit meta/main.yml and assure we can correctly determine full role name:

galaxy_info:
role_name: my_name  # if absent directory name hosting role is used instead
namespace: my_galaxy_namespace  # if absent, author is used instead

Namespace: https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names

As an alternative, you can add 'role-name' to either skip_list or warn_list.

INFO     Using /root/.cache/ansible-lint/af766b/roles/myrole1 symlink to current repository in order to enable Ansible to find the role using its expected full name.
INFO     Added ANSIBLE_ROLES_PATH=~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/root/.cache/ansible-lint/af766b/roles:/root/.cache/ansible-lint/af766b/roles
Traceback (most recent call last):
  File "/opt/toolset/bin/ansible-lint", line 8, in <module>
    sys.exit(_run_cli_entrypoint())
  File "/opt/toolset/lib/python3.8/site-packages/ansiblelint/__main__.py", line 299, in _run_cli_entrypoint
    sys.exit(main(sys.argv))
  File "/opt/toolset/lib/python3.8/site-packages/ansiblelint/__main__.py", line 214, in main
    rules = RulesCollection(options.rulesdirs)
  File "/opt/toolset/lib/python3.8/site-packages/ansiblelint/rules/__init__.py", line 220, in __init__
    for rule in load_plugins(rulesdir):
  File "/opt/toolset/lib/python3.8/site-packages/ansiblelint/rules/__init__.py", line 193, in load_plugins
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/ansible-lint-rules/rules/UseTrueFalseInsteadYesNo.py", line 1, in <module>
    from ansiblelint import AnsibleLintRule
ImportError: cannot import name 'AnsibleLintRule' from 'ansiblelint' (/opt/toolset/lib/python3.8/site-packages/ansiblelint/__init__.py)



